### PR TITLE
remove quotes from help menu

### DIFF
--- a/demisto_sdk/__main__.py
+++ b/demisto_sdk/__main__.py
@@ -639,7 +639,7 @@ def format(
     help="Verbose output", is_flag=True
 )
 def upload(**kwargs):
-    """"Upload integration to Demisto instance.
+    """Upload integration to Demisto instance.
     DEMISTO_BASE_URL environment variable should contain the Demisto server base URL.
     DEMISTO_API_KEY environment variable should contain a valid Demisto API Key.
     * Note: Uploading classifiers to Cortex XSOAR is available from version 6.0.0 and up. *


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
I just ran the sdk help command and saw that the upload command has a quote in the description so i removed it. 

## Screenshots
![image](https://user-images.githubusercontent.com/3606980/121899052-b8f12a80-cd2c-11eb-90f7-35ca7947d5c3.png)

## Must have
- [ ] Tests
- [ ] Documentation
